### PR TITLE
Release of version 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,3 +130,31 @@ all the things that you see...
 * Performance improved
 ### Non-functional
 * Fixedbug that impacted server performance
+
+## Release 3.0.0 (2020-08-10T17:31:54)
+### Features
+* Release of version 2.5.0
+* Update .thoth.yaml
+* Release of version 2.4.0
+* Update .thoth.yaml
+* Release of version 2.3.0
+* Update .thoth.yaml
+* Update .thoth.yaml
+* Release of version 2.2.0
+* Release of version 2.1.0
+* Release of version 2.0.0
+* Release of version 1.2.0
+* Release of version 1.1.0
+* Release of version 1.0.0
+* Added tushar7sharma as a maintainer
+* Added support for new version of Openshift
+* Support for new clusters added
+### Bug Fixes
+* Data bug fixed
+### Improvements
+* Performance improved
+### Non-functional
+* Fixedbug that impacted server performance
+### Automatic Updates
+* :pushpin: Automatic update of dependency deprecated from 1.2.8 to 1.2.9
+* :pushpin: Automatic update of dependency thoth-common from 0.13.7 to 0.13.8

--- a/template/version.py
+++ b/template/version.py
@@ -17,4 +17,4 @@
 
 """This file carries the version of the template project."""
 
-__version__ = "2.5.0"
+__version__ = "3.0.0"


### PR DESCRIPTION
Hey, @tushar7sharma!

Your possible backwards incompatible changes will be released by this PR.

Related: #38```

Changelog:
### Features
* Release of version 2.5.0
* Update .thoth.yaml
* Release of version 2.4.0
* Update .thoth.yaml
* Release of version 2.3.0
* Update .thoth.yaml
* Update .thoth.yaml
* Release of version 2.2.0
* Release of version 2.1.0
* Release of version 2.0.0
* Release of version 1.2.0
* Release of version 1.1.0
* Release of version 1.0.0
* Added tushar7sharma as a maintainer
* Added support for new version of Openshift
* Support for new clusters added
### Bug Fixes
* Data bug fixed
### Improvements
* Performance improved
### Non-functional
* Fixedbug that impacted server performance
### Automatic Updates
* :pushpin: Automatic update of dependency deprecated from 1.2.8 to 1.2.9
* :pushpin: Automatic update of dependency thoth-common from 0.13.7 to 0.13.8```